### PR TITLE
Removing unnecessary for loop in deploy job

### DIFF
--- a/jenkins/jobs/dsl/doa_labs-m7-m8.groovy
+++ b/jenkins/jobs/dsl/doa_labs-m7-m8.groovy
@@ -59,11 +59,7 @@ echo "SSH onto host and unzip war file into webapps folder..."
 ssh -tt -i ${PEM_FILE} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no centos@$TOMCAT_IP "      
       sudo docker stop tomcat8
       sudo rm -rf /data/tomcat/webapps/petclinic
-      for i in $(cd ~/temp; find . -name *.war)
-      do
-        sudo unzip ~/temp/${i} -d /data/tomcat/webapps/petclinic >/dev/null
-      done
-      
+      sudo unzip ~/temp/petclinic.war -d /data/tomcat/webapps/petclinic >/dev/null
       sudo docker start tomcat8
 "      
 


### PR DESCRIPTION
For loop going through temp directory is not needed since job will only ever be looking for one specific artifact.
